### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(test)]
-
 #[macro_use]
 extern crate may;
 #[macro_use]
@@ -75,7 +73,6 @@ pub fn prime(max: usize) -> impl Iterator<Item = usize> + 'static {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
     use super::*;
 
     #[test]
@@ -84,9 +81,9 @@ mod tests {
         assert_eq!(sum, 21536);
     }
 
-    #[bench]
-    fn bench(b: &mut test::Bencher) {
-        may::config().set_workers(4);
-        b.iter(|| prime(1_000_000));
-    }
+    // #[bench]
+    // fn bench(b: &mut test::Bencher) {
+    //     may::config().set_workers(4);
+    //     b.iter(|| prime(1_000_000));
+    // }
 }


### PR DESCRIPTION
Update tests to use the stable testing framework, and commented out #[bench] due to the compiler denying soft_unstable by default.